### PR TITLE
Support High-DPI Scaling and Responsive Window Sizing

### DIFF
--- a/PTSD/include/Util/Input.hpp
+++ b/PTSD/include/Util/Input.hpp
@@ -43,8 +43,9 @@ public:
 
     /**
      * @brief Retrieves the current position of the cursor.
-     * @note The cursor position is relative to the upper-left corner of the
-     * client area of the window.
+     * @note The cursor position is in render-space coordinates:
+     * origin at the center of the drawable viewport,
+     * +x to the right and +y upward.
      *
      * @return The cursor position as vec2(x, y).
      *
@@ -113,8 +114,8 @@ public:
     /**
      * @brief Sets the position of the cursor.
      * @param pos The position to set the cursor to.
-     * @note The cursor position is relative to the upper-left corner of the
-     * client area of the window.
+     * @note `pos` uses the same render-space coordinates as
+     * Util::Input::GetCursorPosition().
      * @note It also generates a mouse motion event, which leads
      * Util::Input::IsMouseMoving() to return true in this update-cycle.
      * @see Util::Input::GetCursorPosition()

--- a/PTSD/src/Core/Context.cpp
+++ b/PTSD/src/Core/Context.cpp
@@ -1,6 +1,8 @@
 #include "Core/Context.hpp"
 
+#include <algorithm>
 #include <memory>
+#include <utility>
 
 #include "Core/DebugMessageCallback.hpp"
 
@@ -13,8 +15,37 @@
 using Util::ms_t;
 
 namespace Core {
+namespace {
+constexpr float kInitialWindowOccupancy = 0.95F;
+
+std::pair<int, int> GetInitialWindowSize() {
+    SDL_DisplayMode desktopMode{};
+    if (SDL_GetDesktopDisplayMode(0, &desktopMode) != 0 || desktopMode.w <= 0 ||
+        desktopMode.h <= 0) {
+        return {static_cast<int>(WINDOW_WIDTH),
+                static_cast<int>(WINDOW_HEIGHT)};
+    }
+
+    const float widthScale =
+        static_cast<float>(desktopMode.w) / static_cast<float>(WINDOW_WIDTH);
+    const float heightScale =
+        static_cast<float>(desktopMode.h) / static_cast<float>(WINDOW_HEIGHT);
+    const float scale =
+        std::min({kInitialWindowOccupancy, widthScale * kInitialWindowOccupancy,
+                  heightScale * kInitialWindowOccupancy});
+
+    const int windowWidth = std::max(1, static_cast<int>(WINDOW_WIDTH * scale));
+    const int windowHeight =
+        std::max(1, static_cast<int>(WINDOW_HEIGHT * scale));
+    return {windowWidth, windowHeight};
+}
+} // namespace
+
 Context::Context() {
     Util::Logger::Init();
+
+    SDL_SetHint(SDL_HINT_WINDOWS_DPI_AWARENESS, "permonitorv2");
+    SDL_SetHint(SDL_HINT_VIDEO_HIGHDPI_DISABLED, "0");
 
     if (SDL_Init(SDL_INIT_VIDEO) < 0) {
         LOG_ERROR("Failed to initialize SDL");
@@ -41,9 +72,12 @@ Context::Context() {
         LOG_ERROR(SDL_GetError());
     }
 
-    m_Window =
-        SDL_CreateWindow(TITLE, WINDOW_POS_X, WINDOW_POS_Y, WINDOW_WIDTH,
-                         WINDOW_HEIGHT, SDL_WINDOW_OPENGL | SDL_WINDOW_SHOWN);
+    const auto [windowWidth, windowHeight] = GetInitialWindowSize();
+
+    m_Window = SDL_CreateWindow(
+        TITLE, WINDOW_POS_X, WINDOW_POS_Y, windowWidth, windowHeight,
+        SDL_WINDOW_OPENGL | SDL_WINDOW_SHOWN | SDL_WINDOW_RESIZABLE |
+            SDL_WINDOW_ALLOW_HIGHDPI);
 
     if (m_Window == nullptr) {
         LOG_ERROR("Failed to create window");

--- a/PTSD/src/Core/Context.cpp
+++ b/PTSD/src/Core/Context.cpp
@@ -18,6 +18,26 @@ namespace Core {
 namespace {
 constexpr float kInitialWindowOccupancy = 0.95F;
 
+void SyncWindowDimensions(SDL_Window *window, unsigned int &windowWidth,
+                          unsigned int &windowHeight) {
+    if (window == nullptr) {
+        return;
+    }
+
+    int queriedWindowWidth = static_cast<int>(windowWidth);
+    int queriedWindowHeight = static_cast<int>(windowHeight);
+    SDL_GetWindowSize(window, &queriedWindowWidth, &queriedWindowHeight);
+
+    int drawableWidth = queriedWindowWidth;
+    int drawableHeight = queriedWindowHeight;
+    SDL_GL_GetDrawableSize(window, &drawableWidth, &drawableHeight);
+
+    windowWidth = static_cast<unsigned int>(
+        drawableWidth > 0 ? drawableWidth : queriedWindowWidth);
+    windowHeight = static_cast<unsigned int>(
+        drawableHeight > 0 ? drawableHeight : queriedWindowHeight);
+}
+
 std::pair<int, int> GetInitialWindowSize() {
     SDL_DisplayMode desktopMode{};
     if (SDL_GetDesktopDisplayMode(0, &desktopMode) != 0 || desktopMode.w <= 0 ||
@@ -83,6 +103,8 @@ Context::Context() {
         LOG_ERROR("Failed to create window");
         LOG_ERROR(SDL_GetError());
     }
+
+    SyncWindowDimensions(m_Window, m_WindowWidth, m_WindowHeight);
 
     SDL_GL_SetAttribute(SDL_GL_CONTEXT_PROFILE_MASK,
                         SDL_GL_CONTEXT_PROFILE_CORE);
@@ -154,14 +176,7 @@ void Context::Setup() {
 }
 
 void Context::Update() {
-    int drawableWidth = static_cast<int>(m_WindowWidth);
-    int drawableHeight = static_cast<int>(m_WindowHeight);
-    SDL_GetWindowSize(m_Window, &drawableWidth, &drawableHeight);
-    SDL_GL_GetDrawableSize(m_Window, &drawableWidth, &drawableHeight);
-    m_WindowWidth = static_cast<unsigned int>(
-        drawableWidth > 0 ? drawableWidth : m_WindowWidth);
-    m_WindowHeight = static_cast<unsigned int>(
-        drawableHeight > 0 ? drawableHeight : m_WindowHeight);
+    SyncWindowDimensions(m_Window, m_WindowWidth, m_WindowHeight);
     glViewport(0, 0, static_cast<GLsizei>(m_WindowWidth),
                static_cast<GLsizei>(m_WindowHeight));
 

--- a/PTSD/src/Util/Input.cpp
+++ b/PTSD/src/Util/Input.cpp
@@ -7,6 +7,36 @@
 
 namespace Util {
 
+namespace {
+glm::vec2 GetScaledMousePosition() {
+    int windowX = 0;
+    int windowY = 0;
+    SDL_GetMouseState(&windowX, &windowY);
+
+    if (SDL_Window *window = SDL_GL_GetCurrentWindow()) {
+        int windowWidth = 0;
+        int windowHeight = 0;
+        int drawableWidth = 0;
+        int drawableHeight = 0;
+
+        SDL_GetWindowSize(window, &windowWidth, &windowHeight);
+        SDL_GL_GetDrawableSize(window, &drawableWidth, &drawableHeight);
+
+        if (windowWidth > 0 && windowHeight > 0 && drawableWidth > 0 &&
+            drawableHeight > 0) {
+            return {static_cast<float>(windowX) *
+                        static_cast<float>(drawableWidth) /
+                        static_cast<float>(windowWidth),
+                    static_cast<float>(windowY) *
+                        static_cast<float>(drawableHeight) /
+                        static_cast<float>(windowHeight)};
+        }
+    }
+
+    return {static_cast<float>(windowX), static_cast<float>(windowY)};
+}
+} // namespace
+
 // init all static members
 SDL_Event Input::s_Event = SDL_Event();
 
@@ -77,10 +107,7 @@ void Input::UpdateKeyState(const SDL_Event *event) {
 }
 
 void Input::Update() {
-    int x, y;
-    SDL_GetMouseState(&x, &y);
-    s_CursorPosition.x = static_cast<float>(x);
-    s_CursorPosition.y = static_cast<float>(y);
+    s_CursorPosition = GetScaledMousePosition();
 
     const glm::vec2 viewportSize = GetViewportSize();
     s_CursorPosition.x -= viewportSize.x / 2;
@@ -122,6 +149,27 @@ glm::vec2 Input::GetCursorPosition() {
 }
 
 void Input::SetCursorPosition(const glm::vec2 &pos) {
+    if (SDL_Window *window = SDL_GL_GetCurrentWindow()) {
+        int windowWidth = 0;
+        int windowHeight = 0;
+        int drawableWidth = 0;
+        int drawableHeight = 0;
+
+        SDL_GetWindowSize(window, &windowWidth, &windowHeight);
+        SDL_GL_GetDrawableSize(window, &drawableWidth, &drawableHeight);
+
+        if (windowWidth > 0 && windowHeight > 0 && drawableWidth > 0 &&
+            drawableHeight > 0) {
+            SDL_WarpMouseInWindow(
+                window,
+                static_cast<int>(pos.x * static_cast<float>(windowWidth) /
+                                 static_cast<float>(drawableWidth)),
+                static_cast<int>(pos.y * static_cast<float>(windowHeight) /
+                                 static_cast<float>(drawableHeight)));
+            return;
+        }
+    }
+
     SDL_WarpMouseInWindow(nullptr, static_cast<int>(pos.x),
                           static_cast<int>(pos.y));
 }

--- a/PTSD/src/Util/Input.cpp
+++ b/PTSD/src/Util/Input.cpp
@@ -8,29 +8,62 @@
 namespace Util {
 
 namespace {
+struct WindowMetrics {
+    int windowWidth = 0;
+    int windowHeight = 0;
+    int drawableWidth = 0;
+    int drawableHeight = 0;
+
+    bool IsValid() const {
+        return windowWidth > 0 && windowHeight > 0 && drawableWidth > 0 &&
+               drawableHeight > 0;
+    }
+};
+
+WindowMetrics GetWindowMetrics(SDL_Window *window) {
+    WindowMetrics metrics;
+    if (window == nullptr) {
+        return metrics;
+    }
+
+    SDL_GetWindowSize(window, &metrics.windowWidth, &metrics.windowHeight);
+    SDL_GL_GetDrawableSize(window, &metrics.drawableWidth,
+                           &metrics.drawableHeight);
+    return metrics;
+}
+
+glm::vec2 ToDrawableCoordinates(const glm::vec2 &windowPos,
+                                const WindowMetrics &metrics) {
+    if (!metrics.IsValid()) {
+        return windowPos;
+    }
+    return {windowPos.x * static_cast<float>(metrics.drawableWidth) /
+                static_cast<float>(metrics.windowWidth),
+            windowPos.y * static_cast<float>(metrics.drawableHeight) /
+                static_cast<float>(metrics.windowHeight)};
+}
+
+glm::vec2 ToWindowCoordinates(const glm::vec2 &drawablePos,
+                              const WindowMetrics &metrics) {
+    if (!metrics.IsValid()) {
+        return drawablePos;
+    }
+    return {drawablePos.x * static_cast<float>(metrics.windowWidth) /
+                static_cast<float>(metrics.drawableWidth),
+            drawablePos.y * static_cast<float>(metrics.windowHeight) /
+                static_cast<float>(metrics.drawableHeight)};
+}
+
 glm::vec2 GetScaledMousePosition() {
     int windowX = 0;
     int windowY = 0;
     SDL_GetMouseState(&windowX, &windowY);
 
     if (SDL_Window *window = SDL_GL_GetCurrentWindow()) {
-        int windowWidth = 0;
-        int windowHeight = 0;
-        int drawableWidth = 0;
-        int drawableHeight = 0;
-
-        SDL_GetWindowSize(window, &windowWidth, &windowHeight);
-        SDL_GL_GetDrawableSize(window, &drawableWidth, &drawableHeight);
-
-        if (windowWidth > 0 && windowHeight > 0 && drawableWidth > 0 &&
-            drawableHeight > 0) {
-            return {static_cast<float>(windowX) *
-                        static_cast<float>(drawableWidth) /
-                        static_cast<float>(windowWidth),
-                    static_cast<float>(windowY) *
-                        static_cast<float>(drawableHeight) /
-                        static_cast<float>(windowHeight)};
-        }
+        const auto metrics = GetWindowMetrics(window);
+        return ToDrawableCoordinates(
+            {static_cast<float>(windowX), static_cast<float>(windowY)},
+            metrics);
     }
 
     return {static_cast<float>(windowX), static_cast<float>(windowY)};
@@ -150,8 +183,17 @@ glm::vec2 Input::GetCursorPosition() {
 
 void Input::SetCursorPosition(const glm::vec2 &pos) {
     if (SDL_Window *window = SDL_GL_GetCurrentWindow()) {
-        SDL_WarpMouseInWindow(window, static_cast<int>(pos.x),
-                              static_cast<int>(pos.y));
+        const auto metrics = GetWindowMetrics(window);
+
+        const glm::vec2 viewportSize = GetViewportSize();
+        const glm::vec2 drawablePos = {
+            pos.x + viewportSize.x / 2.0F,
+            viewportSize.y / 2.0F - pos.y,
+        };
+        const glm::vec2 windowPos = ToWindowCoordinates(drawablePos, metrics);
+
+        SDL_WarpMouseInWindow(window, static_cast<int>(windowPos.x),
+                              static_cast<int>(windowPos.y));
         return;
     }
 

--- a/PTSD/src/Util/Input.cpp
+++ b/PTSD/src/Util/Input.cpp
@@ -150,24 +150,9 @@ glm::vec2 Input::GetCursorPosition() {
 
 void Input::SetCursorPosition(const glm::vec2 &pos) {
     if (SDL_Window *window = SDL_GL_GetCurrentWindow()) {
-        int windowWidth = 0;
-        int windowHeight = 0;
-        int drawableWidth = 0;
-        int drawableHeight = 0;
-
-        SDL_GetWindowSize(window, &windowWidth, &windowHeight);
-        SDL_GL_GetDrawableSize(window, &drawableWidth, &drawableHeight);
-
-        if (windowWidth > 0 && windowHeight > 0 && drawableWidth > 0 &&
-            drawableHeight > 0) {
-            SDL_WarpMouseInWindow(
-                window,
-                static_cast<int>(pos.x * static_cast<float>(windowWidth) /
-                                 static_cast<float>(drawableWidth)),
-                static_cast<int>(pos.y * static_cast<float>(windowHeight) /
-                                 static_cast<float>(drawableHeight)));
-            return;
-        }
+        SDL_WarpMouseInWindow(window, static_cast<int>(pos.x),
+                              static_cast<int>(pos.y));
+        return;
     }
 
     SDL_WarpMouseInWindow(nullptr, static_cast<int>(pos.x),


### PR DESCRIPTION
- Add Windows high-DPI awareness settings.
- Create window with high-DPI and resizable flags.
- Initialize window size based on desktop resolution ratio instead of fixed pixels.
- Normalize mouse coordinates between window size and drawable size.
- Keep input behavior consistent across different DPI scaling settings.