### PR TITLE
68 fix dpi scaling

### DIFF
--- a/PTSD/include/config.hpp
+++ b/PTSD/include/config.hpp
@@ -10,11 +10,11 @@ constexpr const char *TITLE = "Practical Tools for Simple Design";
 constexpr int WINDOW_POS_X = SDL_WINDOWPOS_UNDEFINED;
 constexpr int WINDOW_POS_Y = SDL_WINDOWPOS_UNDEFINED;
 
-// constexpr unsigned int WINDOW_WIDTH = 1280;
-// constexpr unsigned int WINDOW_HEIGHT = 720;
+constexpr unsigned int WINDOW_WIDTH = 1280;
+constexpr unsigned int WINDOW_HEIGHT = 720;
 // Recommand
-constexpr unsigned int WINDOW_WIDTH = 2400;
-constexpr unsigned int WINDOW_HEIGHT = 1350;
+// constexpr unsigned int WINDOW_WIDTH = 2400;
+// constexpr unsigned int WINDOW_HEIGHT = 1350;
 
 constexpr Util::Logger::Level DEFAULT_LOG_LEVEL = Util::Logger::Level::DEBUG;
 

--- a/PTSD/include/config.hpp
+++ b/PTSD/include/config.hpp
@@ -10,11 +10,11 @@ constexpr const char *TITLE = "Practical Tools for Simple Design";
 constexpr int WINDOW_POS_X = SDL_WINDOWPOS_UNDEFINED;
 constexpr int WINDOW_POS_Y = SDL_WINDOWPOS_UNDEFINED;
 
-constexpr unsigned int WINDOW_WIDTH = 1280;
-constexpr unsigned int WINDOW_HEIGHT = 720;
+// constexpr unsigned int WINDOW_WIDTH = 1280;
+// constexpr unsigned int WINDOW_HEIGHT = 720;
 // Recommand
-// constexpr unsigned int WINDOW_WIDTH = 2400;
-// constexpr unsigned int WINDOW_HEIGHT = 1350;
+constexpr unsigned int WINDOW_WIDTH = 2400;
+constexpr unsigned int WINDOW_HEIGHT = 1350;
 
 constexpr Util::Logger::Level DEFAULT_LOG_LEVEL = Util::Logger::Level::DEBUG;
 

--- a/Resources/scoring_config.json
+++ b/Resources/scoring_config.json
@@ -32,6 +32,7 @@
       "normal": 1.0,
       "hard": 1.5,
       "extreme": 2.0
-    }
+    },
+    "star_thresholds": [15000, 30000, 45000]
   }
 }

--- a/include/controllers/BirdLaunchController.hpp
+++ b/include/controllers/BirdLaunchController.hpp
@@ -16,6 +16,7 @@ public:
     void SetOnSpawnCharacter(std::function<void(std::shared_ptr<Character>)> callback) {
         m_OnSpawnCharacter = callback;
     }
+    void SetPhysicsScale(float scale) { m_PhysicsScale = scale; }
 
     [[nodiscard]] bool IsHoldingBird() const { return m_IsHoldingBird; }
     [[nodiscard]] int GetRemainingBirdCountForBonus() const;
@@ -40,6 +41,7 @@ private:
     std::vector<std::shared_ptr<Character>> m_ActiveBirdsInFlight;
     std::function<void(std::shared_ptr<Character>)> m_OnSpawnCharacter = nullptr;
     bool m_HasSplit = false;
+    float m_PhysicsScale = 1.0f;
     // stop detection now uses velocity/angle thresholds
 };
 

--- a/include/levels/LevelTypes.hpp
+++ b/include/levels/LevelTypes.hpp
@@ -17,6 +17,10 @@ struct LevelObjectDefinition
     std::string resourcePath;
     float posX = 0.0f;
     float posY = 0.0f;
+    float rawPercentX = 0.0f; // Raw xPercent value before conversion
+    float rawPercentY = 0.0f; // Raw yPercent value before conversion
+    bool usesPercentX = false;
+    bool usesPercentY = false;
     float scaleX = 1.0f;
     float scaleY = 1.0f;
     float rotation = 0.0f;

--- a/include/scenes/CollisionResponse.hpp
+++ b/include/scenes/CollisionResponse.hpp
@@ -26,7 +26,7 @@ namespace CollisionResponse
     void SolveVelocity(ContactManifold &cm, bool damageEnabled);
 
     // Apply damage accumulated over the solver iterations for this contact.
-    void ApplyAccumulatedDamage(ContactManifold &cm);
+    void ApplyAccumulatedDamage(ContactManifold &cm, float physicsScale = 1.0f);
 
     // Baumgarte position correction – does NOT touch velocities.
     // Run 2-3 times after all velocity iterations per step.

--- a/include/scenes/Scene.hpp
+++ b/include/scenes/Scene.hpp
@@ -139,6 +139,11 @@ protected:
   float m_DamageImmunityTimer = 2.0f;
   [[nodiscard]] bool IsDamageImmune() const { return m_DamageImmunityTimer > 0.0f; }
 
+  // Scaling factor for physics constants (like gravity) to maintain consistent feel across resolutions
+  float m_PhysicsScale = 1.0f;
+  void SetPhysicsScale(float scale) { m_PhysicsScale = scale; }
+  float GetPhysicsScale() const { return m_PhysicsScale; }
+
   // Persisted contact manifolds for warm-starting the SI solver.
   std::vector<ContactManifold> m_Contacts;
 

--- a/include/scenes/ScoringSystem.hpp
+++ b/include/scenes/ScoringSystem.hpp
@@ -22,6 +22,7 @@ public:
     // Difficulty multiplier
     void SetDifficultyMultiplier(float multiplier) { m_DifficultyMultiplier = multiplier; }
     [[nodiscard]] float GetDifficultyMultiplier() const { return m_DifficultyMultiplier; }
+    [[nodiscard]] int GetStarCount(int score) const;
 
     int AwardPigDestroyed();
     int AwardLeftoverBirds(int birdCount);
@@ -39,6 +40,7 @@ private:
     int m_Score = 0;
     int m_HighScore = 0;
     float m_DifficultyMultiplier = 1.0f;
+    std::vector<int> m_StarThresholds;
 
     // Points from config
     int m_PigPoints = 5000;

--- a/src/controllers/BirdLaunchController.cpp
+++ b/src/controllers/BirdLaunchController.cpp
@@ -68,7 +68,7 @@ bool BirdLaunchController::LoadLevelObjects(const std::vector<std::shared_ptr<Ch
             center += position;
         }
         center /= static_cast<float>(slingshotPositions.size());
-        m_BirdAnchorPosition = center + glm::vec2(0.0f, 90.0f);
+        m_BirdAnchorPosition = center + glm::vec2(0.0f, 90.0f * m_PhysicsScale);
     }
 
     if (!m_BirdQueue.empty())
@@ -149,8 +149,8 @@ bool BirdLaunchController::HandleBirdLaunchPhysics()
     const bool mousePressed = Util::Input::IsKeyPressed(Util::Keycode::MOUSE_LB);
     const glm::vec2 mouseWorldPos = GetMouseWorldPosition();
 
-    constexpr float maxPullDistance = 140.0f;
-    constexpr float launchPower = 9.0f;
+    const float maxPullDistance = 140.0f * m_PhysicsScale;
+    const float launchPower = 9.0f; // Do not scale launchPower, as pull distance is already scaled!
     if (!m_HasLaunchedBird)
     {
         if (mousePressed)

--- a/src/levels/LevelObjectFactory.cpp
+++ b/src/levels/LevelObjectFactory.cpp
@@ -327,8 +327,37 @@ std::shared_ptr<Character> LevelObjectFactory::CreateCharacter(const LevelObject
         posY += groupIt->second.offsetY * groupIt->second.scaleMultiplier;
     }
 
-    posX *= runtimeScale;
-    posY *= runtimeScale;
+    // For percent-based positions, convert using actual viewport size directly
+    // to avoid double-scaling (percent -> design pixels -> runtimeScale).
+    // For absolute positions, apply runtimeScale as before.
+    if (objectDefinition.usesPercentX)
+    {
+        const glm::vec2 vpSize = Util::GetViewportSize();
+        posX = (objectDefinition.rawPercentX / 100.0f) * vpSize.x;
+        // Re-apply group offset scaled for viewport
+        if (groupIt != levelData.groupAdjustments.end())
+        {
+            posX += groupIt->second.offsetX * groupIt->second.scaleMultiplier * runtimeScale;
+        }
+    }
+    else
+    {
+        posX *= runtimeScale;
+    }
+    if (objectDefinition.usesPercentY)
+    {
+        const glm::vec2 vpSize = Util::GetViewportSize();
+        posY = (objectDefinition.rawPercentY / 100.0f) * vpSize.y;
+        // Re-apply group offset scaled for viewport
+        if (groupIt != levelData.groupAdjustments.end())
+        {
+            posY += groupIt->second.offsetY * groupIt->second.scaleMultiplier * runtimeScale;
+        }
+    }
+    else
+    {
+        posY *= runtimeScale;
+    }
 
     auto character = std::make_shared<Character>(PrepareResourcePath(resourcePath));
     const glm::vec2 textureSize = character->GetSize();

--- a/src/levels/LevelParser.cpp
+++ b/src/levels/LevelParser.cpp
@@ -35,12 +35,26 @@ ParsedLevelData LevelParser::Parse(const std::string &jsonStr)
         LevelObjectDefinition objectDefinition;
 
         objectDefinition.typeStr = JsonParseUtils::ExtractString(entityJson, "type");
-        objectDefinition.posX = JsonParseUtils::HasKey(entityJson, "xPercent")
-                                    ? JsonParseUtils::ExtractFloat(entityJson, "xPercent") * static_cast<float>(WINDOW_WIDTH) / 100.0f
-                                    : JsonParseUtils::ExtractFloat(entityJson, "x");
-        objectDefinition.posY = JsonParseUtils::HasKey(entityJson, "yPercent")
-                                    ? JsonParseUtils::ExtractFloat(entityJson, "yPercent") * static_cast<float>(WINDOW_HEIGHT) / 100.0f
-                                    : JsonParseUtils::ExtractFloat(entityJson, "y");
+        objectDefinition.usesPercentX = JsonParseUtils::HasKey(entityJson, "xPercent");
+        objectDefinition.usesPercentY = JsonParseUtils::HasKey(entityJson, "yPercent");
+        if (objectDefinition.usesPercentX)
+        {
+            objectDefinition.rawPercentX = JsonParseUtils::ExtractFloat(entityJson, "xPercent");
+            objectDefinition.posX = objectDefinition.rawPercentX * static_cast<float>(WINDOW_WIDTH) / 100.0f;
+        }
+        else
+        {
+            objectDefinition.posX = JsonParseUtils::ExtractFloat(entityJson, "x");
+        }
+        if (objectDefinition.usesPercentY)
+        {
+            objectDefinition.rawPercentY = JsonParseUtils::ExtractFloat(entityJson, "yPercent");
+            objectDefinition.posY = objectDefinition.rawPercentY * static_cast<float>(WINDOW_HEIGHT) / 100.0f;
+        }
+        else
+        {
+            objectDefinition.posY = JsonParseUtils::ExtractFloat(entityJson, "y");
+        }
         objectDefinition.scaleX = JsonParseUtils::ExtractFloat(entityJson, "scaleX");
         objectDefinition.scaleY = JsonParseUtils::ExtractFloat(entityJson, "scaleY");
         objectDefinition.rotation = JsonParseUtils::ExtractFloat(entityJson, "rotation");

--- a/src/scenes/CollisionResponse.cpp
+++ b/src/scenes/CollisionResponse.cpp
@@ -287,7 +287,7 @@ void CollisionResponse::SolvePosition(ContactManifold &cm)
 
 // Apply damage accumulated over the solver iterations for this contact once
 // per physics step. This avoids multiplying damage by the number of iterations.
-void CollisionResponse::ApplyAccumulatedDamage(ContactManifold &cm)
+void CollisionResponse::ApplyAccumulatedDamage(ContactManifold &cm, float physicsScale)
 {
     if (cm.frameAccumulatedNormalImpulse <= 0.f)
         return;
@@ -296,7 +296,8 @@ void CollisionResponse::ApplyAccumulatedDamage(ContactManifold &cm)
     constexpr float kDamageThreshold = 150.f;
     constexpr float kDamageFactor = 0.05f;
 
-    float absJn = cm.frameAccumulatedNormalImpulse;
+    // Un-scale the impulse to make damage resolution-independent
+    float absJn = cm.frameAccumulatedNormalImpulse / (physicsScale > 0.f ? physicsScale : 1.0f);
     if (absJn <= kDamageThreshold)
     {
         cm.frameAccumulatedNormalImpulse = 0.f;

--- a/src/scenes/GameScene.cpp
+++ b/src/scenes/GameScene.cpp
@@ -73,6 +73,19 @@ namespace
         return out.str();
     }
 
+    // Design resolution: all HUD constants below are authored for this resolution.
+    constexpr float kDesignWidth = 2400.0f;
+    constexpr float kDesignHeight = 1350.0f;
+
+    // Returns the scale factor to adapt design-resolution HUD values to the actual viewport.
+    float GetHudScale()
+    {
+        const glm::vec2 viewportSize = Util::GetViewportSize();
+        if (viewportSize.x <= 0.0f || viewportSize.y <= 0.0f)
+            return 1.0f;
+        return std::min(viewportSize.x / kDesignWidth, viewportSize.y / kDesignHeight);
+    }
+
     constexpr float kGameHudButtonScale = 0.85f;
     constexpr float kGameHudLeftPadding = 50.0f;
     constexpr float kGameHudTopPadding = 50.0f;
@@ -160,22 +173,7 @@ namespace
         return stream.str();
     }
 
-    int ComputeStarCount(const int score)
-    {
-        if (score >= 45000)
-        {
-            return 3;
-        }
-        if (score >= 30000)
-        {
-            return 2;
-        }
-        if (score >= 15000)
-        {
-            return 1;
-        }
-        return 0;
-    }
+
 
     float ComputeStarPopScale(const float elapsedTime)
     {
@@ -414,6 +412,13 @@ bool GameScene::LoadLevel(const std::string &levelPath)
     Util::SetCameraZoom(1.0f);
     Util::SetCameraPosition({0.0f, 0.0f});
 
+    const float physicsScale = GetHudScale();
+    SetPhysicsScale(physicsScale);
+    if (m_BirdLaunchController)
+    {
+        m_BirdLaunchController->SetPhysicsScale(physicsScale);
+    }
+
     if (!m_LevelManager || !m_LevelManager->LoadLevel(levelPath))
     {
         return false;
@@ -595,7 +600,7 @@ void GameScene::BuildLevelHud()
     if (!m_ScoreLabel)
     {
         CreateOutlinedTextObjects("SCORE",
-                                  kGameHudScoreLabelSize,
+                                  static_cast<int>(kGameHudScoreLabelSize * GetHudScale()),
                                   {0.0f, 0.0f},
                                   95.0f,
                                   kGameHudTextFillColor,
@@ -612,7 +617,7 @@ void GameScene::BuildLevelHud()
     if (!m_ScoreValue)
     {
         CreateOutlinedTextObjects("0",
-                                  kGameHudScoreValueSize,
+                                  static_cast<int>(kGameHudScoreValueSize * GetHudScale()),
                                   {0.0f, 0.0f},
                                   95.0f,
                                   kGameHudTextFillColor,
@@ -631,7 +636,7 @@ void GameScene::BuildLevelHud()
     if (!m_HighScoreLabel)
     {
         CreateOutlinedTextObjects("HIGHSCORE",
-                                  kGameHudHighScoreLabelSize,
+                                  static_cast<int>(kGameHudHighScoreLabelSize * GetHudScale()),
                                   {0.0f, 0.0f},
                                   95.0f,
                                   kGameHudTextFillColor,
@@ -648,7 +653,7 @@ void GameScene::BuildLevelHud()
     if (!m_HighScoreValue)
     {
         CreateOutlinedTextObjects("0",
-                                  kGameHudHighScoreValueSize,
+                                  static_cast<int>(kGameHudHighScoreValueSize * GetHudScale()),
                                   {0.0f, 0.0f},
                                   95.0f,
                                   kGameHudTextFillColor,
@@ -666,7 +671,7 @@ void GameScene::BuildLevelHud()
 
     m_LeftTopButton093 = std::make_shared<Button>(Resource::Game_Button_093);
     m_LeftTopButton093->SetZIndex(95.0f);
-    m_LeftTopButton093->SetScale({kGameHudButtonScale, kGameHudButtonScale});
+    m_LeftTopButton093->SetScale({kGameHudButtonScale * GetHudScale(), kGameHudButtonScale * GetHudScale()});
     m_LeftTopButton093->SetVisible(true);
     m_LeftTopButton093->SetSFX(Resource::SETTING_SFX);
     m_LeftTopButton093->SetOnClickFunction([this]()
@@ -675,7 +680,7 @@ void GameScene::BuildLevelHud()
 
     m_LeftTopButton031 = std::make_shared<Button>(Resource::Game_Button_031);
     m_LeftTopButton031->SetZIndex(95.0f);
-    m_LeftTopButton031->SetScale({kGameHudButtonScale, kGameHudButtonScale});
+    m_LeftTopButton031->SetScale({kGameHudButtonScale * GetHudScale(), kGameHudButtonScale * GetHudScale()});
     m_LeftTopButton031->SetVisible(true);
     m_LeftTopButton031->SetOnClickFunction([this]()
                                            {
@@ -693,7 +698,7 @@ void GameScene::BuildLevelHud()
 
     m_PauseMenu069 = std::make_shared<Button>(Resource::Game_Menu_Item_069);
     m_PauseMenu069->SetZIndex(96.0f);
-    m_PauseMenu069->SetScale({kGamePauseMenu069Scale, kGamePauseMenu069Scale});
+    m_PauseMenu069->SetScale({kGamePauseMenu069Scale * GetHudScale(), kGamePauseMenu069Scale * GetHudScale()});
     m_PauseMenu069->SetVisible(false);
     m_PauseMenu069->SetSFX(Resource::SETTING_SFX);
     m_PauseMenu069->SetOnClickFunction([this]()
@@ -702,7 +707,7 @@ void GameScene::BuildLevelHud()
 
     m_PauseMenu082 = std::make_shared<Button>(Resource::Game_Menu_Item_082);
     m_PauseMenu082->SetZIndex(96.0f);
-    m_PauseMenu082->SetScale({kGamePauseMenu082Scale, kGamePauseMenu082Scale});
+    m_PauseMenu082->SetScale({kGamePauseMenu082Scale * GetHudScale(), kGamePauseMenu082Scale * GetHudScale()});
     m_PauseMenu082->SetVisible(false);
     m_PauseMenu082->SetSFX(Resource::SETTING_SFX);
     m_PauseMenu082->SetOnClickFunction([this]()
@@ -716,7 +721,7 @@ void GameScene::BuildLevelHud()
 
     m_PauseMenu073 = std::make_shared<Button>(Resource::Game_Menu_Item_073);
     m_PauseMenu073->SetZIndex(96.0f);
-    m_PauseMenu073->SetScale({kGamePauseMenu073Scale, kGamePauseMenu073Scale});
+    m_PauseMenu073->SetScale({kGamePauseMenu073Scale * GetHudScale(), kGamePauseMenu073Scale * GetHudScale()});
     m_PauseMenu073->SetVisible(false);
     m_PauseMenu073->SetSFX(Resource::SETTING_SFX);
     m_PauseMenu073->SetOnClickFunction([this]()
@@ -730,7 +735,7 @@ void GameScene::BuildLevelHud()
 
     m_PauseMenu005 = std::make_shared<Button>(Resource::Game_Menu_Item_005);
     m_PauseMenu005->SetZIndex(96.0f);
-    m_PauseMenu005->SetScale({kGamePauseMenu005Scale, kGamePauseMenu005Scale});
+    m_PauseMenu005->SetScale({kGamePauseMenu005Scale * GetHudScale(), kGamePauseMenu005Scale * GetHudScale()});
     m_PauseMenu005->SetVisible(false);
     m_PauseMenu005->SetSFX(Resource::SETTING_SFX);
     m_PauseMenu005->SetOnClickFunction([this]()
@@ -739,19 +744,19 @@ void GameScene::BuildLevelHud()
 
     m_PauseMenu040Overlay = std::make_shared<Util::GameObject>(
         std::make_shared<Util::Image>(Resource::Game_Menu_Item_040), 97.0f);
-    m_PauseMenu040Overlay->m_Transform.scale = {kGamePauseMenu040Scale, kGamePauseMenu040Scale};
+    m_PauseMenu040Overlay->m_Transform.scale = {kGamePauseMenu040Scale * GetHudScale(), kGamePauseMenu040Scale * GetHudScale()};
     m_PauseMenu040Overlay->SetVisible(false);
     AddElements(m_PauseMenu040Overlay);
 
     m_PauseMenu063 = std::make_shared<Button>(Resource::Game_Menu_Item_063);
     m_PauseMenu063->SetZIndex(96.0f);
-    m_PauseMenu063->SetScale({kGamePauseMenu063Scale, kGamePauseMenu063Scale});
+    m_PauseMenu063->SetScale({kGamePauseMenu063Scale * GetHudScale(), kGamePauseMenu063Scale * GetHudScale()});
     m_PauseMenu063->SetVisible(false);
     AddElements(m_PauseMenu063);
 
     m_PauseMenuLevelTitle = std::make_shared<Util::GameObject>(
         std::make_shared<Util::Image>(Resource::Level_Title_1_1), 96.0f);
-    m_PauseMenuLevelTitle->m_Transform.scale = {kGamePauseMenuLevelTitleScale, kGamePauseMenuLevelTitleScale};
+    m_PauseMenuLevelTitle->m_Transform.scale = {kGamePauseMenuLevelTitleScale * GetHudScale(), kGamePauseMenuLevelTitleScale * GetHudScale()};
     m_PauseMenuLevelTitle->SetVisible(false);
     AddElements(m_PauseMenuLevelTitle);
 
@@ -762,7 +767,7 @@ void GameScene::BuildLevelHud()
     AddElements(m_LevelClearBackdrop);
 
     m_LevelClearTitle = std::make_shared<Util::GameObject>(
-        std::make_shared<Util::Text>(kUIFont, kLevelClearTitleSize, "LEVEL CLEARED!", kGameHudTextFillColor), 98.0f);
+        std::make_shared<Util::Text>(kUIFont, static_cast<int>(kLevelClearTitleSize * GetHudScale()), "LEVEL CLEARED!", kGameHudTextFillColor), 98.0f);
     m_LevelClearTitle->SetVisible(false);
     AddElements(m_LevelClearTitle);
 
@@ -773,20 +778,20 @@ void GameScene::BuildLevelHud()
         emptyStarDrawable->SetOpacity(kLevelClearEmptyStarOpacity);
         m_LevelClearStars[i] = std::make_shared<Util::GameObject>(
             emptyStarDrawable, 97.0f);
-        m_LevelClearStars[i]->m_Transform.scale = {kLevelClearStarScale, kLevelClearStarScale};
+        m_LevelClearStars[i]->m_Transform.scale = {kLevelClearStarScale * GetHudScale(), kLevelClearStarScale * GetHudScale()};
         m_LevelClearStars[i]->SetVisible(false);
         AddElements(m_LevelClearStars[i]);
 
         m_LevelClearEarnedStars[i] = std::make_shared<Util::GameObject>(
             std::make_shared<Util::Image>(Resource::Star_Filled), 97.2f);
-        m_LevelClearEarnedStars[i]->m_Transform.scale = {kLevelClearStarScale, kLevelClearStarScale};
+        m_LevelClearEarnedStars[i]->m_Transform.scale = {kLevelClearStarScale * GetHudScale(), kLevelClearStarScale * GetHudScale()};
         m_LevelClearEarnedStars[i]->SetVisible(false);
         AddElements(m_LevelClearEarnedStars[i]);
     }
 
     // Level Clear Score
     CreateOutlinedTextObjects(FormatScore(0),
-                              kLevelClearScoreValueSize,
+                              static_cast<int>(kLevelClearScoreValueSize * GetHudScale()),
                               {0.0f, 0.0f},
                               97.0f,
                               kLevelClearScoreFillColor,
@@ -805,7 +810,7 @@ void GameScene::BuildLevelHud()
 
     // Level Clear High Score
     CreateOutlinedTextObjects("BEST " + FormatScore(0),
-                              kLevelClearHighScoreValueSize,
+                              static_cast<int>(kLevelClearHighScoreValueSize * GetHudScale()),
                               {0.0f, 0.0f},
                               97.0f,
                               kGameHudTextFillColor,
@@ -833,7 +838,7 @@ void GameScene::BuildLevelHud()
     // Level Clear Buttons
     m_LevelClearMenuButton = std::make_shared<Button>(Resource::Game_Menu_Item_073);
     m_LevelClearMenuButton->SetZIndex(98.0f);
-    m_LevelClearMenuButton->SetScale({kLevelClearButtonScale, kLevelClearButtonScale});
+    m_LevelClearMenuButton->SetScale({kLevelClearButtonScale * GetHudScale(), kLevelClearButtonScale * GetHudScale()});
     m_LevelClearMenuButton->SetVisible(false);
     m_LevelClearMenuButton->SetSFX(Resource::SETTING_SFX);
     m_LevelClearMenuButton->SetOnClickFunction([this]()
@@ -847,7 +852,7 @@ void GameScene::BuildLevelHud()
 
     m_LevelClearRestartButton = std::make_shared<Button>(Resource::Game_Menu_Item_082);
     m_LevelClearRestartButton->SetZIndex(98.0f);
-    m_LevelClearRestartButton->SetScale({kLevelClearButtonScale, kLevelClearButtonScale});
+    m_LevelClearRestartButton->SetScale({kLevelClearButtonScale * GetHudScale(), kLevelClearButtonScale * GetHudScale()});
     m_LevelClearRestartButton->SetVisible(false);
     m_LevelClearRestartButton->SetSFX(Resource::SETTING_SFX);
     m_LevelClearRestartButton->SetOnClickFunction([this]()
@@ -861,7 +866,7 @@ void GameScene::BuildLevelHud()
 
     m_LevelClearNextButton = std::make_shared<Button>(Resource::Game_Menu_Item_078);
     m_LevelClearNextButton->SetZIndex(98.0f);
-    m_LevelClearNextButton->SetScale({kLevelClearButtonScale, kLevelClearButtonScale});
+    m_LevelClearNextButton->SetScale({kLevelClearButtonScale * GetHudScale(), kLevelClearButtonScale * GetHudScale()});
     m_LevelClearNextButton->SetVisible(false);
     m_LevelClearNextButton->SetSFX(Resource::SETTING_SFX);
     m_LevelClearNextButton->SetOnClickFunction([this]()
@@ -879,19 +884,19 @@ void GameScene::BuildLevelHud()
     AddElements(m_LevelFailedBackdrop);
 
     m_LevelFailedTitle = std::make_shared<Util::GameObject>(
-        std::make_shared<Util::Text>(kUIFont, kLevelFailedTitleSize, "LEVEL FAILED!", kGameHudTextFillColor), 98.0f);
+        std::make_shared<Util::Text>(kUIFont, static_cast<int>(kLevelFailedTitleSize * GetHudScale()), "LEVEL FAILED!", kGameHudTextFillColor), 98.0f);
     m_LevelFailedTitle->SetVisible(false);
     AddElements(m_LevelFailedTitle);
 
     m_LevelFailedPig = std::make_shared<Util::GameObject>(
         std::make_shared<Util::Image>(Resource::PIG_SMALL), 98.0f);
-    m_LevelFailedPig->m_Transform.scale = {kLevelFailedPigScale, kLevelFailedPigScale};
+    m_LevelFailedPig->m_Transform.scale = {kLevelFailedPigScale * GetHudScale(), kLevelFailedPigScale * GetHudScale()};
     m_LevelFailedPig->SetVisible(false);
     AddElements(m_LevelFailedPig);
 
     m_LevelFailedMenuButton = std::make_shared<Button>(Resource::Game_Menu_Item_073);
     m_LevelFailedMenuButton->SetZIndex(98.0f);
-    m_LevelFailedMenuButton->SetScale({kLevelFailedButtonScale, kLevelFailedButtonScale});
+    m_LevelFailedMenuButton->SetScale({kLevelFailedButtonScale * GetHudScale(), kLevelFailedButtonScale * GetHudScale()});
     m_LevelFailedMenuButton->SetVisible(false);
     m_LevelFailedMenuButton->SetSFX(Resource::SETTING_SFX);
     m_LevelFailedMenuButton->SetOnClickFunction([this]()
@@ -905,7 +910,7 @@ void GameScene::BuildLevelHud()
 
     m_LevelFailedRestartButton = std::make_shared<Button>(Resource::Game_Menu_Item_082);
     m_LevelFailedRestartButton->SetZIndex(98.0f);
-    m_LevelFailedRestartButton->SetScale({kLevelFailedButtonScale, kLevelFailedButtonScale});
+    m_LevelFailedRestartButton->SetScale({kLevelFailedButtonScale * GetHudScale(), kLevelFailedButtonScale * GetHudScale()});
     m_LevelFailedRestartButton->SetVisible(false);
     m_LevelFailedRestartButton->SetSFX(Resource::SETTING_SFX);
     m_LevelFailedRestartButton->SetOnClickFunction([this]()
@@ -919,7 +924,7 @@ void GameScene::BuildLevelHud()
 
     m_LevelFailedNextButton = std::make_shared<Button>(Resource::Game_Menu_Item_078);
     m_LevelFailedNextButton->SetZIndex(98.0f);
-    m_LevelFailedNextButton->SetScale({kLevelFailedButtonScale, kLevelFailedButtonScale});
+    m_LevelFailedNextButton->SetScale({kLevelFailedButtonScale * GetHudScale(), kLevelFailedButtonScale * GetHudScale()});
     m_LevelFailedNextButton->SetVisible(false);
     m_LevelFailedNextButton->SetSFX(Resource::SETTING_SFX);
     m_LevelFailedNextButton->SetOnClickFunction([this]()
@@ -944,10 +949,11 @@ void GameScene::UpdateHudPositions()
     const glm::vec2 cameraPos = Util::GetCameraPosition();
     const glm::vec2 viewportSize = Util::GetViewportSize();
     const float zoom = Util::GetCameraZoom();
+    const float hudScale = GetHudScale();
     const glm::vec2 topLeftAnchor = cameraPos +
                                     glm::vec2{
-                                        -viewportSize.x * 0.5f / zoom + kGameHudLeftPadding / zoom,
-                                        viewportSize.y * 0.5f / zoom - kGameHudTopPadding / zoom};
+                                        -viewportSize.x * 0.5f / zoom + (kGameHudLeftPadding * hudScale) / zoom,
+                                        viewportSize.y * 0.5f / zoom - (kGameHudTopPadding * hudScale) / zoom};
 
     if (m_LeftTopButton093)
     {
@@ -956,31 +962,31 @@ void GameScene::UpdateHudPositions()
 
     if (m_LeftTopButton031)
     {
-        m_LeftTopButton031->SetPosition(topLeftAnchor + glm::vec2{kGameHudButtonSpacing / zoom, 0.0f});
+        m_LeftTopButton031->SetPosition(topLeftAnchor + glm::vec2{(kGameHudButtonSpacing * hudScale) / zoom, 0.0f});
     }
 
     // High score positioned at top right
     const glm::vec2 topRightAnchor = cameraPos +
                                      glm::vec2{
-                                         viewportSize.x * 0.5f / zoom - kGameHudLeftPadding / zoom,
-                                         viewportSize.y * 0.5f / zoom - kGameHudTopPadding / zoom};
+                                         viewportSize.x * 0.5f / zoom - (kGameHudLeftPadding * hudScale) / zoom,
+                                         viewportSize.y * 0.5f / zoom - (kGameHudTopPadding * hudScale) / zoom};
 
-    const glm::vec2 scoreAnchor = topRightAnchor + glm::vec2{kGameHudScoreOffsetX / zoom, 0.0f};
-    PositionOutlinedTextObjects(scoreAnchor + glm::vec2{0.0f, kGameHudScoreLabelOffsetY / zoom},
+    const glm::vec2 scoreAnchor = topRightAnchor + glm::vec2{(kGameHudScoreOffsetX * hudScale) / zoom, 0.0f};
+    PositionOutlinedTextObjects(scoreAnchor + glm::vec2{0.0f, (kGameHudScoreLabelOffsetY * hudScale) / zoom},
                                 m_ScoreLabelOutline,
                                 m_ScoreLabel,
                                 zoom);
-    PositionOutlinedTextObjects(scoreAnchor + glm::vec2{0.0f, kGameHudScoreValueOffsetY / zoom},
+    PositionOutlinedTextObjects(scoreAnchor + glm::vec2{0.0f, (kGameHudScoreValueOffsetY * hudScale) / zoom},
                                 m_ScoreValueOutline,
                                 m_ScoreValue,
                                 zoom);
 
-    const glm::vec2 highScoreAnchor = topRightAnchor + glm::vec2{kGameHudHighScoreOffsetX / zoom, 0.0f};
-    PositionOutlinedTextObjects(highScoreAnchor + glm::vec2{0.0f, kGameHudHighScoreLabelOffsetY / zoom},
+    const glm::vec2 highScoreAnchor = topRightAnchor + glm::vec2{(kGameHudHighScoreOffsetX * hudScale) / zoom, 0.0f};
+    PositionOutlinedTextObjects(highScoreAnchor + glm::vec2{0.0f, (kGameHudHighScoreLabelOffsetY * hudScale) / zoom},
                                 m_HighScoreLabelOutline,
                                 m_HighScoreLabel,
                                 zoom);
-    PositionOutlinedTextObjects(highScoreAnchor + glm::vec2{0.0f, kGameHudHighScoreValueOffsetY / zoom},
+    PositionOutlinedTextObjects(highScoreAnchor + glm::vec2{0.0f, (kGameHudHighScoreValueOffsetY * hudScale) / zoom},
                                 m_HighScoreValueOutline,
                                 m_HighScoreValue,
                                 zoom);
@@ -989,61 +995,61 @@ void GameScene::UpdateHudPositions()
     {
         m_PauseMenu069->SetPosition(topLeftAnchor +
                                     glm::vec2{
-                                        kGamePauseMenu069OffsetX / zoom,
-                                        -kGamePauseMenu069OffsetY / zoom});
+                                        (kGamePauseMenu069OffsetX * hudScale) / zoom,
+                                        -(kGamePauseMenu069OffsetY * hudScale) / zoom});
     }
 
     if (m_PauseMenu082)
     {
         m_PauseMenu082->SetPosition(topLeftAnchor +
                                     glm::vec2{
-                                        kGamePauseMenu082OffsetX / zoom,
-                                        -kGamePauseMenu082OffsetY / zoom});
+                                        (kGamePauseMenu082OffsetX * hudScale) / zoom,
+                                        -(kGamePauseMenu082OffsetY * hudScale) / zoom});
     }
 
     if (m_PauseMenu073)
     {
         m_PauseMenu073->SetPosition(topLeftAnchor +
                                     glm::vec2{
-                                        kGamePauseMenu073OffsetX / zoom,
-                                        -kGamePauseMenu073OffsetY / zoom});
+                                        (kGamePauseMenu073OffsetX * hudScale) / zoom,
+                                        -(kGamePauseMenu073OffsetY * hudScale) / zoom});
     }
 
     if (m_PauseMenu005)
     {
         m_PauseMenu005->SetPosition(topLeftAnchor +
                                     glm::vec2{
-                                        kGamePauseMenu005OffsetX / zoom,
-                                        -kGamePauseMenu005OffsetY / zoom});
+                                        (kGamePauseMenu005OffsetX * hudScale) / zoom,
+                                        -(kGamePauseMenu005OffsetY * hudScale) / zoom});
     }
 
     if (m_PauseMenu040Overlay)
     {
         m_PauseMenu040Overlay->m_Transform.translation = topLeftAnchor +
                                                          glm::vec2{
-                                                             kGamePauseMenu040OffsetX / zoom,
-                                                             -kGamePauseMenu040OffsetY / zoom};
+                                                             (kGamePauseMenu040OffsetX * hudScale) / zoom,
+                                                             -(kGamePauseMenu040OffsetY * hudScale) / zoom};
         m_PauseMenu040Overlay->m_Transform.scale = {
-            kGamePauseMenu040Scale,
-            kGamePauseMenu040Scale};
+            kGamePauseMenu040Scale * hudScale,
+            kGamePauseMenu040Scale * hudScale};
     }
 
     if (m_PauseMenu063)
     {
         m_PauseMenu063->SetPosition(topLeftAnchor +
                                     glm::vec2{
-                                        kGamePauseMenu063OffsetX / zoom,
-                                        -kGamePauseMenu063OffsetY / zoom});
+                                        (kGamePauseMenu063OffsetX * hudScale) / zoom,
+                                        -(kGamePauseMenu063OffsetY * hudScale) / zoom});
     }
 
     if (m_PauseMenuBackdrop)
     {
         m_PauseMenuBackdrop->m_Transform.translation = cameraPos +
                                                        glm::vec2{
-                                                           -viewportSize.x * 0.5f / zoom + kGamePauseMenuBackdropCenterOffsetX / zoom,
-                                                           kGamePauseMenuBackdropCenterOffsetY / zoom};
+                                                           -viewportSize.x * 0.5f / zoom + (kGamePauseMenuBackdropCenterOffsetX * hudScale) / zoom,
+                                                           (kGamePauseMenuBackdropCenterOffsetY * hudScale) / zoom};
         m_PauseMenuBackdrop->m_Transform.scale = {
-            kGamePauseMenuBackdropWidth / zoom,
+            (kGamePauseMenuBackdropWidth * hudScale) / zoom,
             viewportSize.y * kGamePauseMenuBackdropHeightRatio / zoom};
     }
 
@@ -1051,9 +1057,9 @@ void GameScene::UpdateHudPositions()
     {
         m_PauseMenuLevelTitle->m_Transform.translation = cameraPos +
                                                          glm::vec2{
-                                                             -viewportSize.x * 0.5f / zoom + kGamePauseMenuLevelTitleOffsetX / zoom,
-                                                             kGamePauseMenuLevelTitleOffsetY / zoom};
-        m_PauseMenuLevelTitle->m_Transform.scale = {kGamePauseMenuLevelTitleScale, kGamePauseMenuLevelTitleScale};
+                                                             -viewportSize.x * 0.5f / zoom + (kGamePauseMenuLevelTitleOffsetX * hudScale) / zoom,
+                                                             (kGamePauseMenuLevelTitleOffsetY * hudScale) / zoom};
+        m_PauseMenuLevelTitle->m_Transform.scale = {kGamePauseMenuLevelTitleScale * hudScale, kGamePauseMenuLevelTitleScale * hudScale};
     }
 }
 
@@ -1398,24 +1404,25 @@ void GameScene::UpdateWinState()
     const glm::vec2 viewportSize = Util::GetViewportSize();
     const float zoom = Util::GetCameraZoom();
     const int score = m_ScoringSystem.GetScore();
-    const int stars = ComputeStarCount(score);
+    const int stars = m_ScoringSystem.GetStarCount(score);
     const int highScore = m_ScoringSystem.GetHighScore();
-    const int highScoreStars = ComputeStarCount(highScore);
+    const int highScoreStars = m_ScoringSystem.GetStarCount(highScore);
+    const float hudScale = GetHudScale();
     if (m_LevelClearBackdrop)
     {
         m_LevelClearBackdrop->SetVisible(true);
         m_LevelClearBackdrop->m_Transform.translation = cameraPos;
         m_LevelClearBackdrop->m_Transform.scale = {
-            kLevelClearPanelWidth / zoom,
+            (kLevelClearPanelWidth * hudScale) / zoom,
             viewportSize.y * kLevelClearPanelHeightRatio / zoom};
     }
     if (m_LevelClearTitle)
     {
         m_LevelClearTitle->SetVisible(true);
-        m_LevelClearTitle->m_Transform.translation = cameraPos + glm::vec2{0.0f, kLevelClearTitleOffsetY / zoom};
+        m_LevelClearTitle->m_Transform.translation = cameraPos + glm::vec2{0.0f, (kLevelClearTitleOffsetY * hudScale) / zoom};
     }
-    const float starStartX = -(kLevelClearStarSpacing / zoom);
-    const float baseStarScale = kLevelClearStarScale / zoom;
+    const float starStartX = -((kLevelClearStarSpacing * hudScale) / zoom);
+    const float baseStarScale = (kLevelClearStarScale * hudScale) / zoom;
     for (int i = 0; i < 3; ++i)
     {
         if (!m_LevelClearStars[i])
@@ -1423,8 +1430,8 @@ void GameScene::UpdateWinState()
             continue;
         }
         const glm::vec2 baseStarPosition = cameraPos + glm::vec2{
-            starStartX + static_cast<float>(i) * (kLevelClearStarSpacing / zoom),
-            kLevelClearStarsOffsetY / zoom};
+            starStartX + static_cast<float>(i) * ((kLevelClearStarSpacing * hudScale) / zoom),
+            (kLevelClearStarsOffsetY * hudScale) / zoom};
         const bool earnedStar = i < stars;
         m_LevelClearStars[i]->SetVisible(true);
         m_LevelClearStars[i]->m_Transform.scale = {baseStarScale, baseStarScale};
@@ -1442,7 +1449,7 @@ void GameScene::UpdateWinState()
             if (popScale > 0.0f)
             {
                 const float normalizedProgress = std::clamp(starElapsedTime / kLevelClearStarPopDuration, 0.0f, 1.0f);
-                const float yOffset = (1.0f - normalizedProgress) * (kLevelClearStarPopYOffset / zoom);
+                const float yOffset = (1.0f - normalizedProgress) * ((kLevelClearStarPopYOffset * hudScale) / zoom);
                 m_LevelClearEarnedStars[i]->SetVisible(true);
                 m_LevelClearEarnedStars[i]->m_Transform.scale = {
                     baseStarScale * popScale,
@@ -1473,13 +1480,13 @@ void GameScene::UpdateWinState()
         {
             outline->SetVisible(true);
         }
-        m_LevelClearScore->m_Transform.translation = cameraPos + glm::vec2{0.0f, kLevelClearScoreOffsetY / zoom};
+        m_LevelClearScore->m_Transform.translation = cameraPos + glm::vec2{0.0f, (kLevelClearScoreOffsetY * hudScale) / zoom};
         for (size_t i = 0; i < m_LevelClearScoreOutline.size(); ++i)
         {
             if (m_LevelClearScoreOutline[i])
             {
                 m_LevelClearScoreOutline[i]->m_Transform.translation =
-                    m_LevelClearScore->m_Transform.translation + kGameHudOutlineOffsets[i] / zoom;
+                    m_LevelClearScore->m_Transform.translation + (kGameHudOutlineOffsets[i] * hudScale) / zoom;
             }
         }
     }
@@ -1493,13 +1500,13 @@ void GameScene::UpdateWinState()
         {
             outline->SetVisible(true);
         }
-        m_LevelClearHighScore->m_Transform.translation = cameraPos + glm::vec2{0.0f, kLevelClearHighScoreOffsetY / zoom};
+        m_LevelClearHighScore->m_Transform.translation = cameraPos + glm::vec2{0.0f, (kLevelClearHighScoreOffsetY * hudScale) / zoom};
         for (size_t i = 0; i < m_LevelClearHighScoreOutline.size(); ++i)
         {
             if (m_LevelClearHighScoreOutline[i])
             {
                 m_LevelClearHighScoreOutline[i]->m_Transform.translation =
-                    m_LevelClearHighScore->m_Transform.translation + kGameHudOutlineOffsets[i] / zoom;
+                    m_LevelClearHighScore->m_Transform.translation + (kGameHudOutlineOffsets[i] * hudScale) / zoom;
             }
         }
     }
@@ -1510,10 +1517,10 @@ void GameScene::UpdateWinState()
             continue;
         }
         m_LevelClearBestStars[i]->SetVisible(true);
-        m_LevelClearBestStars[i]->m_Transform.scale = {kLevelClearBestStarScale / zoom, kLevelClearBestStarScale / zoom};
+        m_LevelClearBestStars[i]->m_Transform.scale = {(kLevelClearBestStarScale * hudScale) / zoom, (kLevelClearBestStarScale * hudScale) / zoom};
         m_LevelClearBestStars[i]->m_Transform.translation = cameraPos + glm::vec2{
-            kLevelClearBestStarsOffsetX / zoom + static_cast<float>(i) * (kLevelClearBestStarSpacing / zoom),
-            kLevelClearHighScoreOffsetY / zoom};
+            (kLevelClearBestStarsOffsetX * hudScale) / zoom + static_cast<float>(i) * ((kLevelClearBestStarSpacing * hudScale) / zoom),
+            (kLevelClearHighScoreOffsetY * hudScale) / zoom};
         m_LevelClearBestStars[i]->SetDrawable(std::make_shared<Util::Image>(
             i < highScoreStars ? Resource::Star_Filled : Resource::Star_Empty));
     }
@@ -1521,22 +1528,22 @@ void GameScene::UpdateWinState()
     {
         m_LevelClearMenuButton->SetVisible(true);
         m_LevelClearMenuButton->SetPosition(cameraPos + glm::vec2{
-            -kLevelClearButtonSpacing / zoom,
-            kLevelClearButtonBaseOffsetY / zoom});
+            -(kLevelClearButtonSpacing * hudScale) / zoom,
+            (kLevelClearButtonBaseOffsetY * hudScale) / zoom});
     }
     if (m_LevelClearRestartButton)
     {
         m_LevelClearRestartButton->SetVisible(true);
         m_LevelClearRestartButton->SetPosition(cameraPos + glm::vec2{
             0.0f,
-            kLevelClearButtonBaseOffsetY / zoom});
+            (kLevelClearButtonBaseOffsetY * hudScale) / zoom});
     }
     if (m_LevelClearNextButton)
     {
         m_LevelClearNextButton->SetVisible(true);
         m_LevelClearNextButton->SetPosition(cameraPos + glm::vec2{
-            kLevelClearButtonSpacing / zoom,
-            kLevelClearButtonBaseOffsetY / zoom});
+            (kLevelClearButtonSpacing * hudScale) / zoom,
+            (kLevelClearButtonBaseOffsetY * hudScale) / zoom});
     }
 }
 
@@ -1579,34 +1586,35 @@ void GameScene::UpdateFailState()
     const glm::vec2 viewportSize = Util::GetViewportSize();
     const float zoom = Util::GetCameraZoom();
 
+    const float hudScale = GetHudScale();
     if (m_LevelFailedBackdrop)
     {
         m_LevelFailedBackdrop->SetVisible(true);
         m_LevelFailedBackdrop->m_Transform.translation = cameraPos;
         m_LevelFailedBackdrop->m_Transform.scale = {
-            kLevelClearPanelWidth / zoom,
+            (kLevelClearPanelWidth * hudScale) / zoom,
             viewportSize.y * kLevelClearPanelHeightRatio / zoom};
     }
 
     if (m_LevelFailedTitle)
     {
         m_LevelFailedTitle->SetVisible(true);
-        m_LevelFailedTitle->m_Transform.translation = cameraPos + glm::vec2{0.0f, kLevelFailedTitleOffsetY / zoom};
+        m_LevelFailedTitle->m_Transform.translation = cameraPos + glm::vec2{0.0f, (kLevelFailedTitleOffsetY * hudScale) / zoom};
     }
 
     if (m_LevelFailedPig)
     {
         m_LevelFailedPig->SetVisible(true);
-        m_LevelFailedPig->m_Transform.translation = cameraPos + glm::vec2{0.0f, kLevelFailedPigOffsetY / zoom};
-        m_LevelFailedPig->m_Transform.scale = {kLevelFailedPigScale / zoom, kLevelFailedPigScale / zoom};
+        m_LevelFailedPig->m_Transform.translation = cameraPos + glm::vec2{0.0f, (kLevelFailedPigOffsetY * hudScale) / zoom};
+        m_LevelFailedPig->m_Transform.scale = {(kLevelFailedPigScale * hudScale) / zoom, (kLevelFailedPigScale * hudScale) / zoom};
     }
 
     if (m_LevelFailedMenuButton)
     {
         m_LevelFailedMenuButton->SetVisible(true);
         m_LevelFailedMenuButton->SetPosition(cameraPos + glm::vec2{
-            -kLevelFailedButtonSpacing / zoom,
-            kLevelFailedButtonBaseOffsetY / zoom});
+            -(kLevelFailedButtonSpacing * hudScale) / zoom,
+            (kLevelFailedButtonBaseOffsetY * hudScale) / zoom});
     }
 
     if (m_LevelFailedRestartButton)
@@ -1614,15 +1622,15 @@ void GameScene::UpdateFailState()
         m_LevelFailedRestartButton->SetVisible(true);
         m_LevelFailedRestartButton->SetPosition(cameraPos + glm::vec2{
             0.0f,
-            kLevelFailedButtonBaseOffsetY / zoom});
+            (kLevelFailedButtonBaseOffsetY * hudScale) / zoom});
     }
 
     if (m_LevelFailedNextButton)
     {
         m_LevelFailedNextButton->SetVisible(true);
         m_LevelFailedNextButton->SetPosition(cameraPos + glm::vec2{
-            kLevelFailedButtonSpacing / zoom,
-            kLevelFailedButtonBaseOffsetY / zoom});
+            (kLevelFailedButtonSpacing * hudScale) / zoom,
+            (kLevelFailedButtonBaseOffsetY * hudScale) / zoom});
     }
 }
 

--- a/src/scenes/Scene.cpp
+++ b/src/scenes/Scene.cpp
@@ -366,7 +366,9 @@ void Scene::StepPhysics(float dt)
       {
         constexpr float kFloorDamageImpulseThreshold = 150.0f;
         constexpr float kFloorDamageFactor = 0.05f;
-        const float estimatedImpulse = ch->GetMass() * impactSpeed;
+        
+        // Un-scale the impulse to make damage resolution-independent
+        const float estimatedImpulse = (ch->GetMass() * impactSpeed) / (m_PhysicsScale > 0.0f ? m_PhysicsScale : 1.0f);
         if (estimatedImpulse > kFloorDamageImpulseThreshold)
         {
           const float resistance = CollisionUtils::GetDamageResistance(ch->GetMaterialType());
@@ -766,7 +768,7 @@ void Scene::RunCollisionDetection(int passes, bool stabilizing)
   {
     for (auto &cm : m_Contacts)
     {
-      CollisionResponse::ApplyAccumulatedDamage(cm);
+      CollisionResponse::ApplyAccumulatedDamage(cm, m_PhysicsScale);
     }
   }
 

--- a/src/scenes/Scene.cpp
+++ b/src/scenes/Scene.cpp
@@ -220,7 +220,7 @@ void Scene::StabilizeEnvironment(int steps)
   TraversalGuard guard(*this);
 
   constexpr float localDt = 1.0f / 120.0f; // finer substeps for stabilization
-  constexpr float gravity = 700.0f;
+  const float gravity = 700.0f * GetPhysicsScale();
   // First, run a few positional-only relaxation passes with no gravity to remove
   // tiny initial overlaps caused by level placement rounding. This prevents gravity
   // from immediately driving pieces through small gaps and creating cascade collapse.
@@ -302,7 +302,7 @@ void Scene::StepPhysics(float dt)
   TraversalGuard guard(*this);
 
   // Apply global gravity to all dynamic characters
-  constexpr float kGlobalGravity = 700.0f;
+  const float kGlobalGravity = 700.0f * GetPhysicsScale();
   for (auto &element : m_Elements)
   {
     auto ch = std::dynamic_pointer_cast<Character>(element);

--- a/src/scenes/ScoringSystem.cpp
+++ b/src/scenes/ScoringSystem.cpp
@@ -126,6 +126,25 @@ bool ScoringSystem::LoadConfig(const std::string& configPath)
                 };
             }
         }
+        // Extract star thresholds
+        std::string starThresholdsContent;
+        if (JsonParseUtils::ExtractArrayContent(scoringContent, "star_thresholds", starThresholdsContent))
+        {
+            m_StarThresholds.clear();
+            std::stringstream ss(starThresholdsContent);
+            std::string item;
+            while (std::getline(ss, item, ','))
+            {
+                try
+                {
+                    m_StarThresholds.push_back(std::stoi(item));
+                }
+                catch (const std::exception&)
+                {
+                    // ignore invalid
+                }
+            }
+        }
     }
 
     spdlog::info("Scoring config loaded successfully from: {}", configPath);
@@ -319,7 +338,33 @@ int ScoringSystem::AddScore(const int points)
     return points;
 }
 
-int ScoringSystem::ApplyMultiplier(int basePoints) const
+int ScoringSystem::ApplyMultiplier(const int basePoints) const
 {
-    return static_cast<int>(basePoints * m_DifficultyMultiplier);
+    return static_cast<int>(static_cast<float>(basePoints) * m_DifficultyMultiplier);
+}
+
+int ScoringSystem::GetStarCount(int score) const
+{
+    int stars = 0;
+    if (m_StarThresholds.empty())
+    {
+        // Fallback defaults if config failed to load or array was empty
+        if (score >= 15000) stars = 1;
+        if (score >= 30000) stars = 2;
+        if (score >= 45000) stars = 3;
+        return stars;
+    }
+
+    for (int threshold : m_StarThresholds)
+    {
+        if (score >= threshold)
+        {
+            stars++;
+        }
+        else
+        {
+            break;
+        }
+    }
+    return std::min(stars, 3);
 }


### PR DESCRIPTION
#  PR: Resolution Independence & System Decoupling 

##  Summary
This branch resolves critical scaling issues that prevented the game from rendering or behaving correctly across different screen resolutions (such as shifting from `2400x1350` down to `1280x720`). Additionally, it cleans up hard-coded game logic to adhere to a data-driven architecture. 

The game UI, physics interactions, bird launch speeds, and block destructibility are now 100% resolution-independent.

##  Key Changes & Fixes

### 1. Viewport-Aware Entity Positioning
* **Fixed Double-Scaling Bug**: `LevelParser` previously converted percentage-based positions into absolute pixels prematurely, causing `LevelObjectFactory` to scale them a second time.
* **Update**: Added `rawPercentX/Y` fields to `LevelObjectDefinition`. Percentages are now strictly preserved and only converted into absolute coordinates dynamically at runtime using `Util::GetViewportSize()`.

### 2. HUD & Menu UI Resolution Scaling
* **Dynamic HUD Ratio**: Introduced `GetHudScale()` in `GameScene` to compute a live ratio against the base `2400x1350` design resolution. 
* **UI Adaptation**: All in-game UI components (Score, High Score, Pause Menu, Game Over Screen, and Level Cleared Screen) now multiply their offsets, font sizes, and object scales by `hudScale`.
* **Overlap Fix**: Resolved an issue where pause menu buttons (audio, level select, help) remained huge on smaller screens by explicitly piping the HUD scale to their initializers in `BuildLevelHud()`.

### 3. Resolution-Independent Physics & Damage
* **Consistent Gravity & Launch Speed**: Introduced `m_PhysicsScale` (derived from the viewport size) and passed it to `Scene` and `BirdLaunchController`. Slingshot pull distances now properly constrain to the screen size.
* **Launch Velocity Fix**: Removed an erroneous double-scaling factor on `launchPower` that caused birds to launch incredibly weakly on smaller screens.
* **Damage Threshold Balancing**: Addressed a critical bug where playing on smaller screens made blocks harder to destroy. The impact physics impulses are now dynamically *un-scaled* (`absJn / physicsScale`) inside `Scene.cpp` and `CollisionResponse.cpp`. The `150.f` damage threshold behaves consistently across 4K displays and 720p windows alike.

### 4. Data-Driven Scoring Clean-up
* **Removed Hard-coded Values**: Excised the hard-coded `15000/30000/45000` star thresholds from `GameScene.cpp`.
* **Config Integration**: Added a `"star_thresholds"` array to `Resources/scoring_config.json`.
* **ScoringSystem Update**: Upgraded `ScoringSystem` to load, parse, and enforce these thresholds dynamically via a new `GetStarCount(score)` method.