### PR TITLE
 Fix camera scrolling and panning for long levels

### DIFF
--- a/PTSD/src/Util/TransformUtils.cpp
+++ b/PTSD/src/Util/TransformUtils.cpp
@@ -6,6 +6,11 @@
 #include <glm/gtx/matrix_transform_2d.hpp>
 
 namespace Util {
+namespace {
+glm::vec2 g_CameraPosition{0.0f, 0.0f};
+float g_CameraZoom = 1.0f;
+} // namespace
+
 Core::Matrices ConvertToUniformBufferData(const Util::Transform &transform,
                                           const glm::vec2 &size,
                                           const float zIndex) {
@@ -18,7 +23,9 @@ Core::Matrices ConvertToUniformBufferData(const Util::Transform &transform,
         glm::ortho<float>(0.0F, 1.0F, 0.0F, 1.0F, nearClip, farClip);
     auto view =
         glm::scale(eye, {1.F / WINDOW_WIDTH, 1.F / WINDOW_HEIGHT, 1.F}) *
-        glm::translate(eye, {WINDOW_WIDTH / 2, WINDOW_HEIGHT / 2, 0});
+        glm::translate(eye, {WINDOW_WIDTH / 2, WINDOW_HEIGHT / 2, 0}) *
+        glm::scale(eye, {g_CameraZoom, g_CameraZoom, 1.F}) *
+        glm::translate(eye, {-g_CameraPosition.x, -g_CameraPosition.y, 0.0f});
 
     // TODO: TRS comment
     auto model = glm::translate(eye, {transform.translation, zIndex}) *
@@ -32,11 +39,6 @@ Core::Matrices ConvertToUniformBufferData(const Util::Transform &transform,
 
     return data;
 }
-
-namespace {
-glm::vec2 g_CameraPosition{0.0f, 0.0f};
-float g_CameraZoom = 1.0f;
-} // namespace
 
 void SetCameraZoom(float zoom) {
     g_CameraZoom = std::clamp(zoom, 0.1f, 4.0f);

--- a/src/controllers/SceneInputController.cpp
+++ b/src/controllers/SceneInputController.cpp
@@ -186,9 +186,33 @@ void SceneInputController::HandleBackgroundDrag(bool isBirdHolding)
 
     const float currentZoom = Util::GetCameraZoom();
     const float viewportWidth = Util::GetViewportSize().x;
-    const float maxPanOffsetX = std::max(0.0f, (1.0f - currentZoom) * viewportWidth);
-    const float minWorldOffsetX = -maxPanOffsetX;
-    const float maxWorldOffsetX = maxPanOffsetX;
+
+    // Dynamically calculate level bounds
+    float leftMostX = 0.0f;
+    float rightMostX = viewportWidth / currentZoom;
+    if (m_LevelManager)
+    {
+        for (const auto &obj : m_LevelManager->GetGameObjects())
+        {
+            if (auto ch = std::dynamic_pointer_cast<Character>(obj))
+            {
+                // Calculate original intrinsic position of the object (without current drag offset)
+                const float intrinsicX = ch->GetPosition().x - m_WorldOffsetX;
+                leftMostX = std::min(leftMostX, intrinsicX);
+                rightMostX = std::max(rightMostX, intrinsicX);
+            }
+        }
+    }
+    
+    // Add padding to see past the last object
+    rightMostX += 200.0f;
+
+    const float visibleWidth = viewportWidth / currentZoom;
+    
+    // Min offset allows dragging left to see the right side
+    const float minWorldOffsetX = std::min(0.0f, visibleWidth - rightMostX);
+    // Max offset allows dragging right
+    const float maxWorldOffsetX = std::max(0.0f, -leftMostX);
 
     const float clampedOffsetX = std::clamp(m_WorldOffsetX, minWorldOffsetX, maxWorldOffsetX);
     const float correctionDeltaX = clampedOffsetX - m_WorldOffsetX;
@@ -219,7 +243,7 @@ void SceneInputController::HandleBackgroundDrag(bool isBirdHolding)
 
     if (mousePressed)
     {
-        if (maxPanOffsetX <= 0.0f)
+        if (minWorldOffsetX >= maxWorldOffsetX)
         {
             m_IsHoldingBackground = true;
             m_IsDraggingBackground = false;
@@ -252,7 +276,7 @@ void SceneInputController::HandleBackgroundDrag(bool isBirdHolding)
             return;
         }
 
-        const float rawDeltaX = mousePos.x - m_LastMousePos.x;
+        const float rawDeltaX = (mousePos.x - m_LastMousePos.x) / currentZoom;
         const float clampedWorldOffsetX =
             std::clamp(m_WorldOffsetX + rawDeltaX, minWorldOffsetX, maxWorldOffsetX);
         const float appliedDeltaX = clampedWorldOffsetX - m_WorldOffsetX;


### PR DESCRIPTION
## Description: 
This branch fixes the broken scrolling and zooming functionality, specifically addressing the inability to scroll through longer levels (like Level 2 and Level 5) and the bug where zooming only affected UI elements.

## Summary of Changes:

### Dynamic Panning Boundaries: 
Removed the broken zoom-based panning limits in SceneInputController.cpp. The camera drag bounds are now dynamically calculated by scanning the level objects, allowing the player to pan from the slingshot all the way to the rightmost entity in any level.
### Fixed Render Transform Matrix: 
Fixed a bug in the core engine (TransformUtils.cpp) where g_CameraZoom and g_CameraPosition were completely ignored during rendering. The View Matrix now correctly translates and scales the game world.
### Synchronised Drag Scaling: 
Updated the mouse drag logic so the drag distance scales perfectly with currentZoom, preventing the camera from feeling "slippery" when zoomed in or out.
Seamless UI Integration: Because GameScene.cpp already anticipates camera movements by moving HUD elements in the opposite direction, the HUD seamlessly stays locked to the screen while the physical world pans and zooms behind it.