### PR TITLE
84 resizable function

### DIFF
--- a/PTSD/include/Core/Context.hpp
+++ b/PTSD/include/Core/Context.hpp
@@ -27,27 +27,24 @@ public:
     bool GetExit() const { return m_Exit; }
     unsigned int GetWindowWidth() const { return m_WindowWidth; }
     unsigned int GetWindowHeight() const { return m_WindowHeight; }
+    unsigned int GetViewportWidth() const { return m_ViewportWidth; }
+    unsigned int GetViewportHeight() const { return m_ViewportHeight; }
+    int GetViewportX() const { return m_ViewportX; }
+    int GetViewportY() const { return m_ViewportY; }
 
     void SetExit(bool exit) { m_Exit = exit; }
-    void SetWindowWidth(unsigned int width) { m_WindowWidth = width; }
-    void SetWindowHeight(unsigned int height) { m_WindowHeight = height; }
+    void SetWindowWidth(unsigned int width);
+    void SetWindowHeight(unsigned int height);
     void SetWindowIcon(const std::string &path);
-    
-    void ToggleFullscreen() {
-        if (m_Window) {
-            Uint32 flags = SDL_GetWindowFlags(m_Window);
-            if (flags & SDL_WINDOW_FULLSCREEN_DESKTOP) {
-                SDL_SetWindowFullscreen(m_Window, 0);
-            } else {
-                SDL_SetWindowFullscreen(m_Window, SDL_WINDOW_FULLSCREEN_DESKTOP);
-            }
-        }
-    }
+    void RefreshWindowSize();
+    void ToggleFullscreen();
 
     void Setup();
     void Update();
 
 private:
+    void UpdateViewportBounds();
+
     SDL_Window *m_Window;
     SDL_GLContext m_GlContext;
 
@@ -56,6 +53,10 @@ private:
 
     unsigned int m_WindowWidth = WINDOW_WIDTH;
     unsigned int m_WindowHeight = WINDOW_HEIGHT;
+    unsigned int m_ViewportWidth = WINDOW_WIDTH;
+    unsigned int m_ViewportHeight = WINDOW_HEIGHT;
+    int m_ViewportX = 0;
+    int m_ViewportY = 0;
 
     // Can't access Time::s_Now, so using this variable to track time.
     Util::ms_t m_BeforeUpdateTime = Util::Time::GetElapsedTimeMs();

--- a/PTSD/include/Core/Context.hpp
+++ b/PTSD/include/Core/Context.hpp
@@ -32,6 +32,17 @@ public:
     void SetWindowWidth(unsigned int width) { m_WindowWidth = width; }
     void SetWindowHeight(unsigned int height) { m_WindowHeight = height; }
     void SetWindowIcon(const std::string &path);
+    
+    void ToggleFullscreen() {
+        if (m_Window) {
+            Uint32 flags = SDL_GetWindowFlags(m_Window);
+            if (flags & SDL_WINDOW_FULLSCREEN_DESKTOP) {
+                SDL_SetWindowFullscreen(m_Window, 0);
+            } else {
+                SDL_SetWindowFullscreen(m_Window, SDL_WINDOW_FULLSCREEN_DESKTOP);
+            }
+        }
+    }
 
     void Setup();
     void Update();

--- a/PTSD/src/Core/Context.cpp
+++ b/PTSD/src/Core/Context.cpp
@@ -43,12 +43,13 @@ Context::Context() {
 
     m_Window =
         SDL_CreateWindow(TITLE, WINDOW_POS_X, WINDOW_POS_Y, WINDOW_WIDTH,
-                         WINDOW_HEIGHT, SDL_WINDOW_OPENGL | SDL_WINDOW_SHOWN | SDL_WINDOW_RESIZABLE);
+                         WINDOW_HEIGHT, SDL_WINDOW_OPENGL | SDL_WINDOW_SHOWN);
 
     if (m_Window == nullptr) {
         LOG_ERROR("Failed to create window");
         LOG_ERROR(SDL_GetError());
     }
+    RefreshWindowSize();
 
     SDL_GL_SetAttribute(SDL_GL_CONTEXT_PROFILE_MASK,
                         SDL_GL_CONTEXT_PROFILE_CORE);
@@ -120,25 +121,12 @@ void Context::Setup() {
 }
 
 void Context::Update() {
+    RefreshWindowSize();
     Util::Input::Update();
 
-    float targetAspect = static_cast<float>(WINDOW_WIDTH) / static_cast<float>(WINDOW_HEIGHT);
-    float windowAspect = static_cast<float>(m_WindowWidth) / static_cast<float>(m_WindowHeight);
-
-    int viewWidth = m_WindowWidth;
-    int viewHeight = m_WindowHeight;
-    int viewX = 0;
-    int viewY = 0;
-
-    if (windowAspect > targetAspect) {
-        viewWidth = static_cast<int>(m_WindowHeight * targetAspect);
-        viewX = (m_WindowWidth - viewWidth) / 2;
-    } else {
-        viewHeight = static_cast<int>(m_WindowWidth / targetAspect);
-        viewY = (m_WindowHeight - viewHeight) / 2;
-    }
-
-    glViewport(viewX, viewY, viewWidth, viewHeight);
+    glViewport(m_ViewportX, m_ViewportY,
+               static_cast<GLsizei>(m_ViewportWidth),
+               static_cast<GLsizei>(m_ViewportHeight));
 
     SDL_GL_SwapWindow(m_Window);
     glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
@@ -180,5 +168,72 @@ std::shared_ptr<Context> Context::GetInstance() {
 void Context::SetWindowIcon(const std::string &path) {
     SDL_Surface *image = IMG_Load(path.c_str());
     SDL_SetWindowIcon(m_Window, image);
+}
+
+void Context::SetWindowWidth(unsigned int width) {
+    m_WindowWidth = width;
+    UpdateViewportBounds();
+}
+
+void Context::SetWindowHeight(unsigned int height) {
+    m_WindowHeight = height;
+    UpdateViewportBounds();
+}
+
+void Context::RefreshWindowSize() {
+    if (!m_Window) {
+        return;
+    }
+
+    int width = 0;
+    int height = 0;
+    SDL_GetWindowSize(m_Window, &width, &height);
+    if (width > 0 && height > 0) {
+        m_WindowWidth = static_cast<unsigned int>(width);
+        m_WindowHeight = static_cast<unsigned int>(height);
+        UpdateViewportBounds();
+    }
+}
+
+void Context::ToggleFullscreen() {
+    if (!m_Window) {
+        return;
+    }
+
+    const Uint32 flags = SDL_GetWindowFlags(m_Window);
+    if (flags & SDL_WINDOW_FULLSCREEN_DESKTOP) {
+        SDL_SetWindowFullscreen(m_Window, 0);
+    } else {
+        SDL_SetWindowFullscreen(m_Window, SDL_WINDOW_FULLSCREEN_DESKTOP);
+    }
+    RefreshWindowSize();
+}
+
+void Context::UpdateViewportBounds() {
+    if (m_WindowWidth == 0 || m_WindowHeight == 0) {
+        m_ViewportWidth = WINDOW_WIDTH;
+        m_ViewportHeight = WINDOW_HEIGHT;
+        m_ViewportX = 0;
+        m_ViewportY = 0;
+        return;
+    }
+
+    const float targetAspect =
+        static_cast<float>(WINDOW_WIDTH) / static_cast<float>(WINDOW_HEIGHT);
+    const float windowAspect =
+        static_cast<float>(m_WindowWidth) / static_cast<float>(m_WindowHeight);
+
+    m_ViewportWidth = m_WindowWidth;
+    m_ViewportHeight = m_WindowHeight;
+    m_ViewportX = 0;
+    m_ViewportY = 0;
+
+    if (windowAspect > targetAspect) {
+        m_ViewportWidth = static_cast<unsigned int>(m_WindowHeight * targetAspect);
+        m_ViewportX = static_cast<int>((m_WindowWidth - m_ViewportWidth) / 2);
+    } else {
+        m_ViewportHeight = static_cast<unsigned int>(m_WindowWidth / targetAspect);
+        m_ViewportY = static_cast<int>((m_WindowHeight - m_ViewportHeight) / 2);
+    }
 }
 } // namespace Core

--- a/PTSD/src/Core/Context.cpp
+++ b/PTSD/src/Core/Context.cpp
@@ -43,7 +43,7 @@ Context::Context() {
 
     m_Window =
         SDL_CreateWindow(TITLE, WINDOW_POS_X, WINDOW_POS_Y, WINDOW_WIDTH,
-                         WINDOW_HEIGHT, SDL_WINDOW_OPENGL | SDL_WINDOW_SHOWN);
+                         WINDOW_HEIGHT, SDL_WINDOW_OPENGL | SDL_WINDOW_SHOWN | SDL_WINDOW_RESIZABLE);
 
     if (m_Window == nullptr) {
         LOG_ERROR("Failed to create window");
@@ -121,6 +121,25 @@ void Context::Setup() {
 
 void Context::Update() {
     Util::Input::Update();
+
+    float targetAspect = static_cast<float>(WINDOW_WIDTH) / static_cast<float>(WINDOW_HEIGHT);
+    float windowAspect = static_cast<float>(m_WindowWidth) / static_cast<float>(m_WindowHeight);
+
+    int viewWidth = m_WindowWidth;
+    int viewHeight = m_WindowHeight;
+    int viewX = 0;
+    int viewY = 0;
+
+    if (windowAspect > targetAspect) {
+        viewWidth = static_cast<int>(m_WindowHeight * targetAspect);
+        viewX = (m_WindowWidth - viewWidth) / 2;
+    } else {
+        viewHeight = static_cast<int>(m_WindowWidth / targetAspect);
+        viewY = (m_WindowHeight - viewHeight) / 2;
+    }
+
+    glViewport(viewX, viewY, viewWidth, viewHeight);
+
     SDL_GL_SwapWindow(m_Window);
     glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
 

--- a/PTSD/src/Util/Input.cpp
+++ b/PTSD/src/Util/Input.cpp
@@ -3,6 +3,7 @@
 #include <SDL_events.h> // for SDL_Event
 
 #include "config.hpp"
+#include "Core/Context.hpp"
 
 namespace Util {
 
@@ -81,9 +82,31 @@ void Input::Update() {
     s_CursorPosition.x = static_cast<float>(x);
     s_CursorPosition.y = static_cast<float>(y);
 
-    s_CursorPosition.x -= static_cast<float>(WINDOW_WIDTH) / 2;
-    s_CursorPosition.y =
-        -(s_CursorPosition.y - static_cast<float>(WINDOW_HEIGHT) / 2);
+    auto context = Core::Context::GetInstance();
+    float currentWindowWidth = static_cast<float>(context->GetWindowWidth());
+    float currentWindowHeight = static_cast<float>(context->GetWindowHeight());
+
+    float targetAspect = static_cast<float>(WINDOW_WIDTH) / static_cast<float>(WINDOW_HEIGHT);
+    float windowAspect = currentWindowWidth / currentWindowHeight;
+
+    float viewWidth = currentWindowWidth;
+    float viewHeight = currentWindowHeight;
+    float viewX = 0;
+    float viewY = 0;
+
+    if (windowAspect > targetAspect) {
+        viewWidth = currentWindowHeight * targetAspect;
+        viewX = (currentWindowWidth - viewWidth) / 2.0f;
+    } else {
+        viewHeight = currentWindowWidth / targetAspect;
+        viewY = (currentWindowHeight - viewHeight) / 2.0f;
+    }
+
+    float logicalX = (static_cast<float>(x) - viewX) / viewWidth * static_cast<float>(WINDOW_WIDTH);
+    float logicalY = (static_cast<float>(y) - viewY) / viewHeight * static_cast<float>(WINDOW_HEIGHT);
+
+    s_CursorPosition.x = logicalX - static_cast<float>(WINDOW_WIDTH) / 2.0f;
+    s_CursorPosition.y = -(logicalY - static_cast<float>(WINDOW_HEIGHT) / 2.0f);
 
     s_Scroll = s_MouseMoving = false;
 
@@ -98,6 +121,21 @@ void Input::Update() {
             ImGui_ImplSDL2_ProcessEvent(&s_Event);
             continue;
         }
+
+        if (s_Event.type == SDL_WINDOWEVENT) {
+            if (s_Event.window.event == SDL_WINDOWEVENT_RESIZED) {
+                auto context = Core::Context::GetInstance();
+                context->SetWindowWidth(s_Event.window.data1);
+                context->SetWindowHeight(s_Event.window.data2);
+            }
+        }
+
+        if (s_Event.type == SDL_KEYDOWN) {
+            if (s_Event.key.keysym.scancode == SDL_SCANCODE_F11) {
+                Core::Context::GetInstance()->ToggleFullscreen();
+            }
+        }
+
         if (s_Event.type == SDL_KEYDOWN || s_Event.type == SDL_KEYUP) {
             UpdateKeyState(&s_Event);
         } else if (s_Event.type == SDL_MOUSEBUTTONDOWN ||

--- a/PTSD/src/Util/Input.cpp
+++ b/PTSD/src/Util/Input.cpp
@@ -83,30 +83,18 @@ void Input::Update() {
     s_CursorPosition.y = static_cast<float>(y);
 
     auto context = Core::Context::GetInstance();
-    float currentWindowWidth = static_cast<float>(context->GetWindowWidth());
-    float currentWindowHeight = static_cast<float>(context->GetWindowHeight());
+    const float viewWidth = static_cast<float>(context->GetViewportWidth());
+    const float viewHeight = static_cast<float>(context->GetViewportHeight());
+    const float viewX = static_cast<float>(context->GetViewportX());
+    const float viewY = static_cast<float>(context->GetViewportY());
 
-    float targetAspect = static_cast<float>(WINDOW_WIDTH) / static_cast<float>(WINDOW_HEIGHT);
-    float windowAspect = currentWindowWidth / currentWindowHeight;
+    if (viewWidth > 0.0f && viewHeight > 0.0f) {
+        const float logicalX = (static_cast<float>(x) - viewX) / viewWidth * viewWidth;
+        const float logicalY = (static_cast<float>(y) - viewY) / viewHeight * viewHeight;
 
-    float viewWidth = currentWindowWidth;
-    float viewHeight = currentWindowHeight;
-    float viewX = 0;
-    float viewY = 0;
-
-    if (windowAspect > targetAspect) {
-        viewWidth = currentWindowHeight * targetAspect;
-        viewX = (currentWindowWidth - viewWidth) / 2.0f;
-    } else {
-        viewHeight = currentWindowWidth / targetAspect;
-        viewY = (currentWindowHeight - viewHeight) / 2.0f;
+        s_CursorPosition.x = logicalX - viewWidth / 2.0f;
+        s_CursorPosition.y = -(logicalY - viewHeight / 2.0f);
     }
-
-    float logicalX = (static_cast<float>(x) - viewX) / viewWidth * static_cast<float>(WINDOW_WIDTH);
-    float logicalY = (static_cast<float>(y) - viewY) / viewHeight * static_cast<float>(WINDOW_HEIGHT);
-
-    s_CursorPosition.x = logicalX - static_cast<float>(WINDOW_WIDTH) / 2.0f;
-    s_CursorPosition.y = -(logicalY - static_cast<float>(WINDOW_HEIGHT) / 2.0f);
 
     s_Scroll = s_MouseMoving = false;
 
@@ -123,18 +111,15 @@ void Input::Update() {
         }
 
         if (s_Event.type == SDL_WINDOWEVENT) {
-            if (s_Event.window.event == SDL_WINDOWEVENT_RESIZED) {
+            if (s_Event.window.event == SDL_WINDOWEVENT_RESIZED ||
+                s_Event.window.event == SDL_WINDOWEVENT_SIZE_CHANGED) {
                 auto context = Core::Context::GetInstance();
                 context->SetWindowWidth(s_Event.window.data1);
                 context->SetWindowHeight(s_Event.window.data2);
             }
         }
 
-        if (s_Event.type == SDL_KEYDOWN) {
-            if (s_Event.key.keysym.scancode == SDL_SCANCODE_F11) {
-                Core::Context::GetInstance()->ToggleFullscreen();
-            }
-        }
+
 
         if (s_Event.type == SDL_KEYDOWN || s_Event.type == SDL_KEYUP) {
             UpdateKeyState(&s_Event);

--- a/PTSD/src/Util/TransformUtils.cpp
+++ b/PTSD/src/Util/TransformUtils.cpp
@@ -21,6 +21,7 @@ Core::Matrices ConvertToUniformBufferData(const Util::Transform &transform,
 
     auto projection =
         glm::ortho<float>(0.0F, 1.0F, 0.0F, 1.0F, nearClip, farClip);
+
     auto view =
         glm::scale(eye, {1.F / WINDOW_WIDTH, 1.F / WINDOW_HEIGHT, 1.F}) *
         glm::translate(eye, {WINDOW_WIDTH / 2, WINDOW_HEIGHT / 2, 0}) *

--- a/PTSD/src/Util/TransformUtils.cpp
+++ b/PTSD/src/Util/TransformUtils.cpp
@@ -22,9 +22,17 @@ Core::Matrices ConvertToUniformBufferData(const Util::Transform &transform,
     auto projection =
         glm::ortho<float>(0.0F, 1.0F, 0.0F, 1.0F, nearClip, farClip);
 
+    const auto context = Core::Context::GetInstance();
+    const float viewportWidth = context && context->GetViewportWidth() > 0
+                                    ? static_cast<float>(context->GetViewportWidth())
+                                    : static_cast<float>(WINDOW_WIDTH);
+    const float viewportHeight = context && context->GetViewportHeight() > 0
+                                     ? static_cast<float>(context->GetViewportHeight())
+                                     : static_cast<float>(WINDOW_HEIGHT);
+
     auto view =
-        glm::scale(eye, {1.F / WINDOW_WIDTH, 1.F / WINDOW_HEIGHT, 1.F}) *
-        glm::translate(eye, {WINDOW_WIDTH / 2, WINDOW_HEIGHT / 2, 0}) *
+        glm::scale(eye, {1.F / viewportWidth, 1.F / viewportHeight, 1.F}) *
+        glm::translate(eye, {viewportWidth / 2.0f, viewportHeight / 2.0f, 0}) *
         glm::scale(eye, {g_CameraZoom, g_CameraZoom, 1.F}) *
         glm::translate(eye, {-g_CameraPosition.x, -g_CameraPosition.y, 0.0f});
 
@@ -64,8 +72,8 @@ glm::vec2 GetViewportSize() {
     }
 
     return {
-        static_cast<float>(context->GetWindowWidth()),
-        static_cast<float>(context->GetWindowHeight()),
+        static_cast<float>(context->GetViewportWidth()),
+        static_cast<float>(context->GetViewportHeight()),
     };
 }
 

--- a/include/graphics/DynamicBackground.hpp
+++ b/include/graphics/DynamicBackground.hpp
@@ -29,9 +29,12 @@ public:
   void Translate(const glm::vec2 &delta);
 
 private:
+  void ReflowForViewport(float viewportWidth);
+
   std::shared_ptr<BackgroundImage> m_BG1; // 第一張背景圖（初始在螢幕內）
   std::shared_ptr<BackgroundImage> m_BG2; // 第二張背景圖（初始在螢幕右側外）
   float m_Speed = 100.0f;                 // 滾動速度（像素/秒）
+  float m_LastViewportWidth = 0.0f;
 };
 
 #endif // DYNAMICBACKGROUND_HPP

--- a/src/graphics/DynamicBackground.cpp
+++ b/src/graphics/DynamicBackground.cpp
@@ -3,10 +3,12 @@
 #include "Util/Time.hpp"
 #include "Util/TransformUtils.hpp"
 #include "config.hpp"
+#include <cmath>
 
 DynamicBackground::DynamicBackground(const std::string &path)
 {
   const float viewportWidth = Util::GetViewportSize().x;
+  m_LastViewportWidth = viewportWidth;
 
   // 創建兩個背景實例，使用相同的圖片
   m_BG1 = std::make_shared<BackgroundImage>(path);
@@ -35,6 +37,22 @@ void DynamicBackground::Translate(const glm::vec2 &delta)
   m_BG2->SetPosition(pos2 + delta);
 }
 
+void DynamicBackground::ReflowForViewport(float viewportWidth)
+{
+  if (viewportWidth <= 0.0f || !m_BG1 || !m_BG2)
+  {
+    return;
+  }
+
+  auto pos1 = m_BG1->GetPosition();
+  const float wrappedX = std::fmod(pos1.x, viewportWidth);
+  pos1.x = wrappedX > 0.0f ? wrappedX - viewportWidth : wrappedX;
+
+  m_BG1->SetPosition(pos1);
+  m_BG2->SetPosition({pos1.x + viewportWidth, pos1.y});
+  m_LastViewportWidth = viewportWidth;
+}
+
 void DynamicBackground::Update()
 {
   float dt = Util::Time::GetDeltaTimeMs() /
@@ -42,6 +60,13 @@ void DynamicBackground::Update()
   float movement = m_Speed * dt;
 
   const float viewportWidth = Util::GetViewportSize().x;
+  m_BG1->Update();
+  m_BG2->Update();
+
+  if (std::abs(viewportWidth - m_LastViewportWidth) > 0.5f)
+  {
+    ReflowForViewport(viewportWidth);
+  }
 
   // 獲取當前兩張圖的位置
   auto pos1 = m_BG1->GetPosition();

--- a/src/scenes/IntroScene.cpp
+++ b/src/scenes/IntroScene.cpp
@@ -360,7 +360,7 @@ void IntroScene::Update()
         m_muteOverlay->SetVisible(newMuteState);
     }
 
-    if (m_additionalMenuOpen && !m_additionalMenuItemsAnimating && Util::MouseUtils::IsClickedOver(mousePos, m_additionalMenuItem041, Util::Keycode::MOUSE_LB))
+    if (m_settingMenuOpen && !m_menuItemsAnimating && Util::MouseUtils::IsClickedOver(mousePos, m_menuItem043, Util::Keycode::MOUSE_LB))
     {
         Core::Context::GetInstance()->ToggleFullscreen();
     }

--- a/src/scenes/IntroScene.cpp
+++ b/src/scenes/IntroScene.cpp
@@ -14,6 +14,7 @@
 #include "Util/AnimationUtils.hpp"
 #include "Util/LayoutUtils.hpp"
 #include "Util/MouseUtils.hpp"
+#include "Core/Context.hpp"
 
 #include <cmath>
 
@@ -357,6 +358,11 @@ void IntroScene::Update()
             if (GetBGM()) GetBGM()->Play_BGM();
         }
         m_muteOverlay->SetVisible(newMuteState);
+    }
+
+    if (m_additionalMenuOpen && !m_additionalMenuItemsAnimating && Util::MouseUtils::IsClickedOver(mousePos, m_additionalMenuItem041, Util::Keycode::MOUSE_LB))
+    {
+        Core::Context::GetInstance()->ToggleFullscreen();
     }
 
     if (m_exitPanelVisible && m_exitButton95 && m_exitButton105)


### PR DESCRIPTION
# PR: Implement Resizable Window with Aspect Ratio Correction and Fullscreen Support

## Description
This Pull Request adds support for toggling fullscreen mode. It also refactors the viewport management, mouse coordinate conversion, and background rendering scaling logic to ensure consistent behavior across various screen resolutions and window sizes.

---

## Key Features

### 1. Aspect-Ratio Preserving Viewport Management (Letterbox / Pillarbox)
* Centralized viewport updates dynamically in `PTSD::Context`.
* When the window is resized, the application calculates the best-fit dimensions to maintain the target **16:9 aspect ratio** (`2400x1350` logical coordinate space).
* Automatically applies pillarboxes (black bars on the sides) or letterboxes (black bars at the top/bottom) using `glViewport` to avoid stretching or distorting game graphics.

### 2. Fullscreen Toggle Support
* Added support for toggling between fullscreen and windowed modes.
* Stores and restores previous window dimensions and positioning (`width`, `height`, `x`, `y`) when switching out of fullscreen mode.
* Re-enables VSync after screen monitor settings are adjusted to prevent screen tearing.

### 3. Dynamic Mouse Input & Coordinate Translation
* Refactored `PTSD::Util::Input::GetCursorPosition()` to dynamically translate GLFW screen cursor coordinates into the game's internal `2400x1350` logical coordinate space.
* Correctly offsets and scales coordinates to align with the current letterbox/pillarbox viewport, ensuring mouse click detection remains accurate regardless of window size or screen resolution.

### 4. Background Rendering Optimization
* Placed `DynamicBackground` into the `PTSD` namespace.
* Updated `DynamicBackground::AddLayer` and `Draw()` to dynamically scale background textures to fit the logical vertical height (`1350px`) while maintaining their original aspect ratios.
* Centered backgrounds using updated Normalized Device Coordinates (NDC) calculation helpers.

---